### PR TITLE
Dockerfile & Helm Chart

### DIFF
--- a/.draftignore
+++ b/.draftignore
@@ -1,0 +1,4 @@
+*.swp
+*.tmp
+*.temp
+.git*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM golang:1.8
+WORKDIR /go/src/app
+COPY . .
+
+#Go
+RUN go-wrapper download   # "go get -d -v ./..."
+RUN go-wrapper install    # "go install -v ./..."
+
+#Install Node
+RUN apt-get update -y
+RUN apt-get install -y node \
+    npm
+RUN npm install --prefix ./app -g
+
+CMD ["go-wrapper", "run"] # ["app"]
+CMD ["npm", "start"]
+EXPOSE 8080

--- a/chart/.helmignore
+++ b/chart/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: A Helm chart for Kubernetes
+name: wrinkled-walrus
+version: 0.1.0

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -1,0 +1,15 @@
+
+{{- if contains "NodePort" .Values.service.type }}
+  Get the application URL by running these commands:
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT/login
+{{- else if contains "LoadBalancer" .Values.service.type }}
+  Get the application URL by running these commands:
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.externalPort }}
+{{- else }}
+  http://{{ .Release.Name }}.{{ .Values.basedomain }} to access your application
+{{- end }}

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+spec:
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}
+    spec:
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.registry }}/{{ .Values.image.org }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - containerPort: {{ .Values.service.internalPort }}
+        livenessProbe:
+          httpGet:
+            path: /
+            port: {{ .Values.service.internalPort }}
+        readinessProbe:
+          httpGet:
+            path: /
+            port: {{ .Values.service.internalPort }}
+        resources:
+{{ toYaml .Values.resources | indent 12 }}

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -1,0 +1,15 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+spec:
+  rules:
+  - host: {{ .Release.Name }}.{{ .Values.basedomain }}
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: {{ template "fullname" . }}
+          servicePort: {{ .Values.service.externalPort }}

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+  - port: {{ .Values.service.externalPort }}
+    targetPort: {{ .Values.service.internalPort }}
+    protocol: TCP
+    name: {{ .Values.service.name }}
+  selector:
+    app: {{ template "fullname" . }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,0 +1,22 @@
+# Default values for golang.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+replicaCount: 2
+image:
+  registry: docker.io
+  org: library
+  name: golang
+  tag: onbuild
+  pullPolicy: IfNotPresent
+service:
+  name: golang
+  type: ClusterIP
+  externalPort: 80
+  internalPort: 8080
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi

--- a/draft.toml
+++ b/draft.toml
@@ -1,0 +1,6 @@
+[environments]
+  [environments.development]
+    name = "wrinkled-walrus"
+    namespace = "default"
+    watch = true
+    watch_delay = 2

--- a/kube-deployment.yaml
+++ b/kube-deployment.yaml
@@ -1,0 +1,81 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  annotations:
+    deployment.kubernetes.io/revision: "1"
+  creationTimestamp: 2017-07-25T23:48:54Z
+  generation: 1
+  labels:
+    chart: wrinkled-walrus-0.1.0
+  name: wrinkled-walrus-wrinkled-walrus
+  namespace: default
+  resourceVersion: "33032"
+  selfLink: /apis/extensions/v1beta1/namespaces/default/deployments/wrinkled-walrus-wrinkled-walrus
+  uid: d158ca7a-7193-11e7-a32c-000d3a35c77e
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: wrinkled-walrus-wrinkled-walrus
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: wrinkled-walrus-wrinkled-walrus
+    spec:
+      containers:
+      - image: xgsnq27y6ymrm.azurecr.io/draft/wrinkled-walrus:74a3216a4098fc51865c8276b04a2aba9fb82974
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: wrinkled-walrus
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status:
+  conditions:
+  - lastTransitionTime: 2017-07-25T23:48:54Z
+    lastUpdateTime: 2017-07-25T23:48:54Z
+    message: Deployment does not have minimum availability.
+    reason: MinimumReplicasUnavailable
+    status: "False"
+    type: Available
+  observedGeneration: 1
+  replicas: 2
+  unavailableReplicas: 2
+  updatedReplicas: 2

--- a/kube-service.yaml
+++ b/kube-service.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: 2017-07-25T23:48:54Z
+  labels:
+    chart: wrinkled-walrus-0.1.0
+  name: wrinkled-walrus-wrinkled-walrus
+  namespace: default
+  resourceVersion: "33009"
+  selfLink: /api/v1/namespaces/default/services/wrinkled-walrus-wrinkled-walrus
+  uid: d156e00e-7193-11e7-a32c-000d3a35c77e
+spec:
+  clusterIP: 10.0.78.57
+  ports:
+  - name: golang
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: wrinkled-walrus-wrinkled-walrus
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}


### PR DESCRIPTION
Using Draft to create Helm charts, started work on Dockerfile and export of Kubernetes deployment and service definitions in YAML (for use in Kube cluster without helm installed)